### PR TITLE
Add pkg-config to buildtool dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,7 @@
   <buildtool_depend>ament_cmake_core</buildtool_depend>
   <buildtool_depend>ament_cmake_test</buildtool_depend>
   <buildtool_depend>ament_cmake_vendor_package</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
 
   <build_depend>assimp-dev</build_depend>
   <build_depend>ffmpeg-dev</build_depend>


### PR DESCRIPTION
pkg-config is required to find `GTS` dependency needed to build the `graphics` component