### PR TITLE
Add .sh env hook for setting GZ_CONFIG_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,10 +67,7 @@ ament_export_dependencies(
 
 if(NOT ${${LIB_NAME_FULL}_FOUND})
   ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.dsv.in")
-  # Create a dummy .sh file needed for ament_package to source the .dsv file.
-  # See https://github.com/ament/ament_package/issues/145
-  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.sh "# Dummy .sh file needed for .dsv file to be sourced.")
-  ament_environment_hooks("${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.sh")
+  ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.sh.in")
 endif()
 
 # The goal is to support versionless package names once the user has found the

--- a/gz_common_vendor.sh.in
+++ b/gz_common_vendor.sh.in
@@ -1,0 +1,3 @@
+if [ -d "$AMENT_CURRENT_PREFIX/opt/@PROJECT_NAME@/share/gz" ]; then
+  ament_prepend_unique_value GZ_CONFIG_PATH "$AMENT_CURRENT_PREFIX/opt/@PROJECT_NAME@/share/gz"
+fi


### PR DESCRIPTION
For systems not using colcon's or ament's `.dsv` files for initializing the environment, having only "dummy" `.sh` hooks means that the `GZ_CONFIG_PATH` environment variable does not get set correctly. The proposed change is to define a "real" `.sh` hook with the proper logic to initialize the environment.

The same issue applies to many of the `gz_*_vendor` packages and I can create similar PRs for them, but wanted to get feedback from maintainers first to avoid potential spamming.